### PR TITLE
Doxygen: Exclude LineSDK::Editor

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -926,7 +926,10 @@ EXCLUDE_PATTERNS       =
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories use the pattern */test/*
 
-EXCLUDE_SYMBOLS        = LineSDK::CallbackPayload LineSDK::FlattenAction LineSDK::NativeInterface
+EXCLUDE_SYMBOLS        = LineSDK::CallbackPayload \
+                         LineSDK::FlattenAction \
+                         LineSDK::NativeInterface \
+                         LineSDK::Editor
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include


### PR DESCRIPTION
When using Doxygen 1.8.5, for some reason, private class `LineSDK::Editor` is included in output as an empty page. Added it to `EXCLUDE_SYMBOLS` param in `Doxyfile`.