### PR TITLE
add necessary configuration after unity 2019.3

### DIFF
--- a/LINE_SDK_Unity/Assets/Plugins/Android/mainTemplate.gradle
+++ b/LINE_SDK_Unity/Assets/Plugins/Android/mainTemplate.gradle
@@ -14,6 +14,10 @@ buildscript {
     }
 }
 
+configurations {
+      compileClasspath
+}
+
 allprojects {
     repositories {
         google()


### PR DESCRIPTION
## Summary
Add necessary section in build.gradle to prevent android build error.

Similar issues and solution discussion can be found below:

* https://youtrack.jetbrains.com/issue/KT-27170

* https://github.com/OneSignal/OneSignal-Unity-SDK/issues/257#issuecomment-643013090

