### PR TITLE
Migrates to using AndroidX libraries

### DIFF
--- a/LINE_SDK_Unity/Assets/Plugins/Android/gradleTemplate.properties
+++ b/LINE_SDK_Unity/Assets/Plugins/Android/gradleTemplate.properties
@@ -1,0 +1,5 @@
+org.gradle.jvmargs=-Xmx**JVM_HEAP_SIZE**M
+org.gradle.parallel=true
+**ADDITIONAL_PROPERTIES**
+android.useAndroidX=true
+android.enableJetifier=true

--- a/LINE_SDK_Unity/Assets/Plugins/Android/gradleTemplate.properties.meta
+++ b/LINE_SDK_Unity/Assets/Plugins/Android/gradleTemplate.properties.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a9e699a8903804cecb5cb12ec21fc7ab
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Migrates to using AndroidX to prevent duplicate class exception from implementing both AndroidX and support libraries.

This is to fix https://github.com/line/line-sdk-unity/issues/24

According to Google [doc](https://developer.android.com/jetpack/androidx#using_androidx_libraries_in_your_project), when using AndroidX, we have to set the following Android Gradle plugin flags to true in your Android project's gradle.properties file.
- android.useAndroidX
- android.enableJetifier

Therefore, in order for Unity to generate a custom gradle.properties file when building Android apks, we have to add **gradleTemplate.properties** and specify the two flags in it according to [the answer](https://stackoverflow.com/a/62803048). 